### PR TITLE
Changed DPI to DPI_BUTTON

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -305,7 +305,7 @@ pub enum Button {
     Scroll,
     Forward,
     Back,
-    DPI,
+    DPI_BUTTON,
     ScrollUp,
     ScrollDown,
 }

--- a/src/config/bind/mod.rs
+++ b/src/config/bind/mod.rs
@@ -81,7 +81,7 @@ fn id_from_btn(button: Button) -> u8 {
         Button::Right => 2,
         Button::Forward => 5,
         Button::Back => 4,
-        Button::DPI => 20,
+        Button::DPI_BUTTON => 20,
         Button::ScrollUp => 16,
         Button::ScrollDown => 17,
     }


### PR DESCRIPTION
A very small change, changed the field 'DPI' to 'DPI_BUTTON' in the Button struct so it no longer conflicts with the DPI subcommand under 'bind'